### PR TITLE
Improve tabletop client interactions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', 'react-hooks'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/prop-types': 'off',
+  },
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VTRPG</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "vtrpg-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "prop-types": "^15.8.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.3",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "vite": "^5.4.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+// @ts-check
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev -- --host --port 4173',
+    port: 4173,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true,
+  },
+});

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,181 @@
+.app-shell {
+  min-height: 100vh;
+  padding: 1.5rem;
+  background: radial-gradient(circle at 20% 20%, rgba(94, 234, 212, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(94, 234, 212, 0.08), transparent 25%),
+    #0f172a;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card {
+  background: #0b1220;
+  border: 1px solid #1e293b;
+  border-radius: 12px;
+  padding: 1rem;
+  max-width: 480px;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.card input,
+.card select,
+.card button,
+.inline-form input,
+.inline-form button {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #1e293b;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.card button,
+.inline-form button {
+  background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+  color: #0b1220;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+}
+
+.room {
+  display: grid;
+  gap: 1rem;
+}
+
+.room-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dropzone {
+  border: 2px dashed #334155;
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  color: #94a3b8;
+}
+
+.dropzone--disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.upload-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.upload {
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  background: #0b1220;
+  border: 1px solid #1e293b;
+}
+
+.upload--pending {
+  border-color: #fde68a;
+  color: #fbbf24;
+}
+
+.upload--done {
+  border-color: #bbf7d0;
+  color: #4ade80;
+}
+
+.upload--failed {
+  border-color: #fecdd3;
+  color: #f43f5e;
+}
+
+.canvas {
+  background: #020617;
+  min-height: 60vh;
+  border-radius: 12px;
+  border: 1px solid #1e293b;
+  overflow: hidden;
+  position: relative;
+  touch-action: none;
+}
+
+.canvas-inner {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem;
+  transition: transform 0.05s ease-out;
+}
+
+.canvas-layer {
+  position: relative;
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 0.5rem;
+  max-width: 320px;
+  max-height: 320px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.canvas-layer img {
+  object-fit: contain;
+}
+
+.canvas-layer--pending img {
+  opacity: 0.6;
+  filter: grayscale(0.8);
+}
+
+.canvas-layer--failed {
+  border-color: #f43f5e;
+}
+
+.badge {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: #0ea5e9;
+  color: #0b1220;
+  font-size: 0.75rem;
+}
+
+.badge--pending {
+  background: #fbbf24;
+  color: #0b1220;
+}
+
+.badge--failed {
+  background: #f43f5e;
+  color: #fff;
+}
+
+.error {
+  color: #f43f5e;
+  font-weight: 600;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,61 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import Login from './components/Login.jsx';
+import Room from './components/Room.jsx';
+import './App.css';
+
+const useWebSocket = (roomId, onMessage) => {
+  useEffect(() => {
+    if (!roomId) return undefined;
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const socket = new WebSocket(`${protocol}://${window.location.host}/ws/rooms/${roomId}`);
+    socket.addEventListener('message', (event) => {
+      try {
+        const parsed = JSON.parse(event.data);
+        onMessage(parsed);
+      } catch (error) {
+        console.error('Failed to parse message', error);
+      }
+    });
+    return () => socket.close();
+  }, [roomId, onMessage]);
+};
+
+const App = () => {
+  const [user, setUser] = useState(null);
+  const [roomId, setRoomId] = useState('alpha');
+  const [sharedImages, setSharedImages] = useState([]);
+
+  const handleMessage = useCallback((message) => {
+    if (message?.type === 'SharedImage') {
+      setSharedImages((prev) => {
+        const existing = prev.find((img) => img.id === message.payload.id);
+        if (existing) {
+          return prev.map((img) => (img.id === message.payload.id ? message.payload : img));
+        }
+        return [...prev, message.payload];
+      });
+    }
+  }, []);
+
+  useWebSocket(roomId, handleMessage);
+
+  const sortedImages = useMemo(
+    () => [...sharedImages].sort((a, b) => new Date(a.createdAt || 0) - new Date(b.createdAt || 0)),
+    [sharedImages]
+  );
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Virtual TTRPG Board</h1>
+      </header>
+      {!user ? (
+        <Login onLogin={(profile) => setUser(profile)} defaultRoom={roomId} onRoomChange={setRoomId} />
+      ) : (
+        <Room roomId={roomId} user={user} images={sortedImages} onImagesUpdate={setSharedImages} />
+      )}
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -1,0 +1,119 @@
+import { useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const Canvas = ({ images }) => {
+  const containerRef = useRef(null);
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [draggingPointer, setDraggingPointer] = useState(null);
+  const [lastPos, setLastPos] = useState({ x: 0, y: 0 });
+  const pointers = useRef(new Map());
+  const pinchDistance = useRef(null);
+
+  const handleWheel = (event) => {
+    event.preventDefault();
+    const delta = -event.deltaY;
+    const nextScale = clamp(scale + delta * 0.001, 0.25, 3);
+    setScale(nextScale);
+  };
+
+  const handlePointerDown = (event) => {
+    containerRef.current?.setPointerCapture(event.pointerId);
+    pointers.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    if (pointers.current.size === 1) {
+      setDraggingPointer(event.pointerId);
+      setLastPos({ x: event.clientX, y: event.clientY });
+    }
+    if (pointers.current.size === 2) {
+      const [first, second] = Array.from(pointers.current.values());
+      pinchDistance.current = Math.hypot(second.x - first.x, second.y - first.y);
+    }
+  };
+
+  const handlePointerUp = (event) => {
+    containerRef.current?.releasePointerCapture(event.pointerId);
+    pointers.current.delete(event.pointerId);
+    if (draggingPointer === event.pointerId) {
+      setDraggingPointer(null);
+    }
+    if (pointers.current.size < 2) {
+      pinchDistance.current = null;
+    }
+  };
+
+  const handlePointerMove = (event) => {
+    if (!pointers.current.has(event.pointerId)) return;
+    const previous = pointers.current.get(event.pointerId);
+    const updated = { x: event.clientX, y: event.clientY };
+    pointers.current.set(event.pointerId, updated);
+
+    if (pointers.current.size === 2 && pinchDistance.current) {
+      const [first, second] = Array.from(pointers.current.values());
+      const nextDistance = Math.hypot(second.x - first.x, second.y - first.y);
+      const delta = nextDistance / pinchDistance.current;
+      setScale((prev) => clamp(prev * delta, 0.25, 3));
+      pinchDistance.current = nextDistance;
+      return;
+    }
+
+    if (draggingPointer === event.pointerId) {
+      const dx = updated.x - previous.x;
+      const dy = updated.y - previous.y;
+      setOffset((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
+      setLastPos(updated);
+    }
+  };
+
+  const gallery = useMemo(
+    () =>
+      images.map((image) => (
+        <div
+          className={`canvas-layer ${image.status ? `canvas-layer--${image.status}` : ''}`}
+          key={image.id || image.url}
+        >
+          <img
+            src={image.url}
+            alt={image.name || 'Shared image'}
+            loading="lazy"
+            draggable={false}
+            style={{ maxWidth: '100%', maxHeight: '100%' }}
+          />
+          {image.status && <span className={`badge badge--${image.status}`}>{image.status}</span>}
+        </div>
+      )),
+    [images]
+  );
+
+  return (
+    <div
+      className="canvas"
+      ref={containerRef}
+      onWheel={handleWheel}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onPointerLeave={handlePointerUp}
+      onPointerMove={handlePointerMove}
+      style={{ cursor: draggingPointer ? 'grabbing' : 'grab' }}
+    >
+      <div
+        className="canvas-inner"
+        style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})` }}
+      >
+        {gallery}
+      </div>
+    </div>
+  );
+};
+
+Canvas.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    url: PropTypes.string,
+    status: PropTypes.string,
+  })).isRequired,
+};
+
+export default Canvas;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const Login = ({ onLogin, defaultRoom, onRoomChange }) => {
+  const [name, setName] = useState('');
+  const [role, setRole] = useState('gm');
+  const [room, setRoom] = useState(defaultRoom || 'alpha');
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onLogin({ name, role });
+    onRoomChange(room);
+  };
+
+  return (
+    <form className="card" onSubmit={handleSubmit}>
+      <h2>Join a room</h2>
+      <label>
+        Room
+        <input
+          value={room}
+          onChange={(e) => setRoom(e.target.value)}
+          required
+          placeholder="Room"
+        />
+      </label>
+      <label>
+        Display name
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="Display name"
+        />
+      </label>
+      <label>
+        Role
+        <select value={role} onChange={(e) => setRole(e.target.value)}>
+          <option value="gm">Spelledare</option>
+          <option value="player">Spelare</option>
+        </select>
+      </label>
+      <button type="submit">Enter</button>
+    </form>
+  );
+};
+
+Login.propTypes = {
+  onLogin: PropTypes.func.isRequired,
+  defaultRoom: PropTypes.string,
+  onRoomChange: PropTypes.func.isRequired,
+};
+
+export default Login;

--- a/src/components/Room.jsx
+++ b/src/components/Room.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import Canvas from './Canvas.jsx';
+
+const fetchImages = async (roomId) => {
+  const response = await fetch(`/rooms/${roomId}/images`);
+  if (!response.ok) throw new Error('Failed to load images');
+  return response.json();
+};
+
+const Room = ({ roomId, user, images, onImagesUpdate }) => {
+  const dropRef = useRef(null);
+  const urlInputRef = useRef(null);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    fetchImages(roomId)
+      .then((data) => onImagesUpdate(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [roomId, onImagesUpdate]);
+
+  const handleDrop = async (event) => {
+    event.preventDefault();
+    if (user.role !== 'gm') return;
+    const urlFromDrop = event.dataTransfer?.getData('text/uri-list') || event.dataTransfer?.getData('text');
+    if (urlFromDrop) {
+      await submitUrl(urlFromDrop);
+      return;
+    }
+
+    const files = Array.from(event.dataTransfer?.files || []).filter((file) => file.size > 0);
+    if (!files.length) return;
+    setError('');
+    setUploading((prev) => [...prev, ...files.map((file) => ({ name: file.name, status: 'pending' }))]);
+    try {
+      const formData = new FormData();
+      files.forEach((file) => formData.append('file', file));
+      const response = await fetch(`/rooms/${roomId}/images`, { method: 'POST', body: formData });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.message || 'Upload failed');
+      onImagesUpdate((prev) => [...prev, ...(Array.isArray(payload) ? payload : [payload])]);
+      setUploading((prev) => prev.map((item) => ({ ...item, status: 'done' })));
+    } catch (err) {
+      setError(err.message);
+      setUploading((prev) => prev.map((item) => ({ ...item, status: 'failed' })));
+    } finally {
+      setTimeout(() => setUploading([]), 1200);
+    }
+  };
+
+  const handlePaste = async (event) => {
+    if (user.role !== 'gm') return;
+    const url = event.clipboardData?.getData('text');
+    if (!url) return;
+    await submitUrl(url);
+  };
+
+  const submitUrl = async (url) => {
+    if (!/^https?:\/\//.test(url)) return;
+    const confirmed = window.confirm(`Dela denna bild-URL?\n${url}`);
+    if (!confirmed) return;
+    try {
+      setError('');
+      const response = await fetch(`/rooms/${roomId}/images`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.message || 'Share failed');
+      onImagesUpdate((prev) => [...prev, payload]);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleDragOver = (event) => {
+    event.preventDefault();
+  };
+
+  const handleUrlSubmit = async (event) => {
+    event.preventDefault();
+    const url = urlInputRef.current.value;
+    urlInputRef.current.value = '';
+    await submitUrl(url);
+  };
+
+  return (
+    <section className="room">
+      <header className="room-header">
+        <div>
+          <h2>Room: {roomId}</h2>
+          <p>
+            Inloggad som {user.name} ({user.role === 'gm' ? 'Spelledare' : 'Spelare'})
+          </p>
+        </div>
+        {user.role === 'gm' && (
+          <form className="inline-form" onSubmit={handleUrlSubmit}>
+            <input ref={urlInputRef} placeholder="Klistra in bild-URL" />
+            <button type="submit">Dela URL</button>
+          </form>
+        )}
+      </header>
+
+      {error && <p className="error">{error}</p>}
+      {loading && <p>Laddar bilder...</p>}
+
+      <div
+        ref={dropRef}
+        className={`dropzone ${user.role !== 'gm' ? 'dropzone--disabled' : ''}`}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onPaste={handlePaste}
+      >
+        {user.role === 'gm' ? 'Släpp filer eller klistra in URL/bild' : 'Endast visning - väntar på spelledaren'}
+      </div>
+
+      {uploading.length > 0 && (
+        <ul className="upload-list">
+          {uploading.map((item) => (
+            <li key={item.name} className={`upload upload--${item.status}`}>
+              {item.name} - {item.status}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Canvas images={images} />
+    </section>
+  );
+};
+
+Room.propTypes = {
+  roomId: PropTypes.string.isRequired,
+  user: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    role: PropTypes.string.isRequired,
+  }).isRequired,
+  images: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    url: PropTypes.string,
+    status: PropTypes.string,
+  })).isRequired,
+  onImagesUpdate: PropTypes.func.isRequired,
+};
+
+export default Room;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+const mockImage = { id: 'demo', url: 'https://placekitten.com/400/400', status: 'done' };
+
+test.describe('drag-drop and zoom', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/rooms/*/images', (route, request) => {
+      if (request.method() === 'GET') {
+        return route.fulfill({ status: 200, body: JSON.stringify([mockImage]) });
+      }
+      if (request.method() === 'POST') {
+        return route.fulfill({ status: 200, body: JSON.stringify({ ...mockImage, id: 'upload' }) });
+      }
+      return route.fallback();
+    });
+  });
+
+  test('game master uploads and zooms', async ({ page }) => {
+    await page.goto('/');
+    await page.fill('input[placeholder="Room"]', 'alpha');
+    await page.fill('input[placeholder="Display name"]', 'GM');
+    await page.selectOption('select', 'gm');
+    await page.click('button:has-text("Enter")');
+
+    await expect(page.getByText('Släpp filer')).toBeVisible();
+
+    const file = await page.evaluateHandle(() => {
+      const data = new DataTransfer();
+      const file = new File(['hello'], 'greeting.txt', { type: 'text/plain' });
+      data.items.add(file);
+      return data;
+    });
+
+    const dropzone = page.locator('.dropzone');
+    await dropzone.dispatchEvent('dragover');
+    await dropzone.dispatchEvent('drop', { dataTransfer: file });
+
+    await expect(page.getByText(/greeting.txt/)).toBeVisible();
+
+    const canvas = page.locator('.canvas');
+    await canvas.hover();
+    await page.mouse.wheel(0, -400);
+    const transform = await page.locator('.canvas-inner').evaluate((el) => el.style.transform);
+    expect(transform).toContain('scale(');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- stabilize WebSocket handling and login inputs to match automation hooks
- harden GM upload/sharing by accepting dropped URLs, clearing errors, and resetting status badges
- add touch-friendly pinch zoom plus per-image status styling for the canvas

## Testing
- npm install (fails: registry access forbidden)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dbb46d854832299e5ddc3aabcefe1)