### PR TITLE
Add synchronized WebGL dice overlay simulation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "dependencies": {
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "three": "^0.182.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.45.3",
+        "@playwright/test": "^1.57.0",
         "@vitejs/plugin-react": "^4.3.1",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.2",
@@ -4143,6 +4144,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "three": "^0.182.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/src/App.css
+++ b/src/App.css
@@ -118,6 +118,66 @@
   z-index: 1;
 }
 
+.dice-overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+}
+
+.dice-canvas {
+  width: 720px;
+  height: 420px;
+  max-width: 100%;
+  max-height: 100%;
+  pointer-events: none;
+  filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.4));
+}
+
+.dice-controls {
+  pointer-events: auto;
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid #1e293b;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.dice-controls button {
+  border: 1px solid #1e293b;
+  background: #22d3ee;
+  color: #0b1220;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+}
+
+.roll-button {
+  background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+}
+
+.dice-count,
+.dice-status {
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.dice-buttons {
+  display: flex;
+  gap: 0.25rem;
+}
+
 .canvas-inner {
   position: relative;
   width: 100%;

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import DiceOverlay from './DiceOverlay.jsx';
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
-const Canvas = ({ images, isGM, onUploadFiles, onShareUrl, onMoveImage, onRemoveImage }) => {
+const Canvas = ({ images, isGM, onUploadFiles, onShareUrl, onMoveImage, onRemoveImage, roomId }) => {
   const containerRef = useRef(null);
   const [scale, setScale] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -49,6 +50,7 @@ const Canvas = ({ images, isGM, onUploadFiles, onShareUrl, onMoveImage, onRemove
   };
 
   const startPan = (event) => {
+    if (event.target.closest('.dice-controls')) return;
     if (dragging.id || panning.active) return;
     panOrigin.current = { x: event.clientX, y: event.clientY, startX: pan.x, startY: pan.y };
     containerRef.current?.setPointerCapture(event.pointerId);
@@ -176,6 +178,7 @@ const Canvas = ({ images, isGM, onUploadFiles, onShareUrl, onMoveImage, onRemove
       onPaste={handlePaste}
       style={{ cursor: dragging.id || panning.active ? 'grabbing' : 'grab' }}
     >
+      <DiceOverlay roomId={roomId} />
       <div className="canvas-inner" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${scale})` }}>
         {!images.length && isGM && <p className="canvas-hint">Drop images or URLs directly onto the board</p>}
         {gallery}
@@ -197,6 +200,7 @@ Canvas.propTypes = {
   onShareUrl: PropTypes.func,
   onMoveImage: PropTypes.func,
   onRemoveImage: PropTypes.func,
+  roomId: PropTypes.string,
 };
 
 export default Canvas;

--- a/src/components/DiceOverlay.jsx
+++ b/src/components/DiceOverlay.jsx
@@ -1,0 +1,292 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import * as THREE from 'three';
+
+const ARENA_WIDTH = 720;
+const ARENA_HEIGHT = 420;
+const DIE_SIZE = 32;
+const FIXED_DT = 1 / 60;
+const MAX_STEPS = 420;
+
+const mulberry32 = (seed) => {
+  let t = seed + 0x6d2b79f5;
+  return () => {
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const createDieMesh = () => {
+  const geometry = new THREE.BoxGeometry(DIE_SIZE, DIE_SIZE, DIE_SIZE);
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0.2, roughness: 0.6 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  return mesh;
+};
+
+const DiceOverlay = ({ roomId }) => {
+  const canvasRef = useRef(null);
+  const rendererRef = useRef(null);
+  const sceneRef = useRef(null);
+  const diceRef = useRef([]);
+  const stepRef = useRef(0);
+  const animationRef = useRef(null);
+  const channelRef = useRef(null);
+  const [diceCount, setDiceCount] = useState(2);
+  const [status, setStatus] = useState('idle');
+
+  const channelName = useMemo(() => `vtrpg-dice-${roomId || 'default'}`, [roomId]);
+
+  const teardown = () => {
+    if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    diceRef.current = [];
+    stepRef.current = 0;
+  };
+
+  const setupScene = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+    renderer.setSize(ARENA_WIDTH, ARENA_HEIGHT);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.shadowMap.enabled = true;
+
+    const scene = new THREE.Scene();
+    scene.background = null;
+
+    const camera = new THREE.PerspectiveCamera(45, ARENA_WIDTH / ARENA_HEIGHT, 1, 1000);
+    camera.position.set(0, -200, 350);
+    camera.lookAt(0, 0, 0);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.85);
+    const directional = new THREE.DirectionalLight(0xffffff, 0.9);
+    directional.position.set(120, -80, 140);
+    directional.castShadow = true;
+
+    scene.add(ambient);
+    scene.add(directional);
+
+    rendererRef.current = { renderer, camera };
+    sceneRef.current = scene;
+  };
+
+  const randomInRange = (rng, min, max) => min + (max - min) * rng();
+
+  const seedDice = (seed, count) => {
+    const rng = mulberry32(seed);
+    const dice = Array.from({ length: count }, () => {
+      const mesh = createDieMesh();
+      return {
+        mesh,
+        position: {
+          x: randomInRange(rng, -ARENA_WIDTH / 2 + DIE_SIZE, ARENA_WIDTH / 2 - DIE_SIZE),
+          y: randomInRange(rng, -ARENA_HEIGHT / 2 + DIE_SIZE, ARENA_HEIGHT / 2 - DIE_SIZE),
+        },
+        velocity: {
+          x: randomInRange(rng, -240, 240),
+          y: randomInRange(rng, 180, 320),
+        },
+        angularVelocity: {
+          x: randomInRange(rng, -4, 4),
+          y: randomInRange(rng, -4, 4),
+          z: randomInRange(rng, -4, 4),
+        },
+        rotation: {
+          x: randomInRange(rng, 0, Math.PI * 2),
+          y: randomInRange(rng, 0, Math.PI * 2),
+          z: randomInRange(rng, 0, Math.PI * 2),
+        },
+      };
+    });
+
+    diceRef.current = dice;
+    stepRef.current = 0;
+  };
+
+  const resolveCollisions = () => {
+    const dice = diceRef.current;
+    for (let i = 0; i < dice.length; i += 1) {
+      for (let j = i + 1; j < dice.length; j += 1) {
+        const a = dice[i];
+        const b = dice[j];
+        const dx = b.position.x - a.position.x;
+        const dy = b.position.y - a.position.y;
+        const distance = Math.sqrt(dx * dx + dy * dy) || 1;
+        const minDist = DIE_SIZE;
+        if (distance < minDist) {
+          const overlap = (minDist - distance) / 2;
+          const nx = dx / distance;
+          const ny = dy / distance;
+          a.position.x -= nx * overlap;
+          a.position.y -= ny * overlap;
+          b.position.x += nx * overlap;
+          b.position.y += ny * overlap;
+
+          const va = a.velocity.x * nx + a.velocity.y * ny;
+          const vb = b.velocity.x * nx + b.velocity.y * ny;
+          const exchange = vb - va;
+          a.velocity.x += exchange * nx;
+          a.velocity.y += exchange * ny;
+          b.velocity.x -= exchange * nx;
+          b.velocity.y -= exchange * ny;
+        }
+      }
+    }
+  };
+
+  const stepPhysics = () => {
+    const dice = diceRef.current;
+    dice.forEach((die) => {
+      die.position.x += die.velocity.x * FIXED_DT;
+      die.position.y += die.velocity.y * FIXED_DT;
+
+      die.rotation.x += die.angularVelocity.x * FIXED_DT;
+      die.rotation.y += die.angularVelocity.y * FIXED_DT;
+      die.rotation.z += die.angularVelocity.z * FIXED_DT;
+
+      die.velocity.x *= 0.992;
+      die.velocity.y *= 0.992;
+      die.angularVelocity.x *= 0.985;
+      die.angularVelocity.y *= 0.985;
+      die.angularVelocity.z *= 0.985;
+
+      const limitX = ARENA_WIDTH / 2 - DIE_SIZE / 2;
+      const limitY = ARENA_HEIGHT / 2 - DIE_SIZE / 2;
+      if (die.position.x < -limitX) {
+        die.position.x = -limitX;
+        die.velocity.x *= -0.82;
+      } else if (die.position.x > limitX) {
+        die.position.x = limitX;
+        die.velocity.x *= -0.82;
+      }
+      if (die.position.y < -limitY) {
+        die.position.y = -limitY;
+        die.velocity.y *= -0.82;
+      } else if (die.position.y > limitY) {
+        die.position.y = limitY;
+        die.velocity.y *= -0.82;
+      }
+    });
+
+    resolveCollisions();
+  };
+
+  const renderFrame = () => {
+    const { renderer, camera } = rendererRef.current || {};
+    const scene = sceneRef.current;
+    if (!renderer || !camera || !scene) return;
+
+    diceRef.current.forEach((die) => {
+      if (!scene.children.includes(die.mesh)) scene.add(die.mesh);
+      die.mesh.position.set(die.position.x, die.position.y, 0);
+      die.mesh.rotation.set(die.rotation.x, die.rotation.y, die.rotation.z);
+    });
+
+    renderer.render(scene, camera);
+  };
+
+  const tick = () => {
+    stepPhysics();
+    renderFrame();
+    stepRef.current += 1;
+
+    const stillMoving = diceRef.current.some(
+      (die) =>
+        Math.abs(die.velocity.x) > 2 ||
+        Math.abs(die.velocity.y) > 2 ||
+        Math.abs(die.angularVelocity.x) > 0.2 ||
+        Math.abs(die.angularVelocity.y) > 0.2 ||
+        Math.abs(die.angularVelocity.z) > 0.2
+    );
+
+    if (stepRef.current < MAX_STEPS && stillMoving) {
+      animationRef.current = requestAnimationFrame(tick);
+    } else {
+      setStatus('settled');
+    }
+  };
+
+  const startSimulation = (seed, count) => {
+    teardown();
+    seedDice(seed, count);
+    setStatus('rolling');
+    animationRef.current = requestAnimationFrame(tick);
+  };
+
+  useEffect(() => {
+    setupScene();
+
+    return () => {
+      teardown();
+      rendererRef.current?.renderer?.dispose();
+      rendererRef.current = null;
+      sceneRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return undefined;
+    const channel = new BroadcastChannel(channelName);
+    channelRef.current = channel;
+    const handler = (event) => {
+      const { type, payload } = event.data || {};
+      if (type === 'dice-roll' && payload?.seed && payload?.count) {
+        startSimulation(payload.seed, payload.count);
+      }
+    };
+    channel.addEventListener('message', handler);
+
+    return () => {
+      channel.removeEventListener('message', handler);
+      channel.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelName]);
+
+  const broadcastRoll = (seed, count) => {
+    channelRef.current?.postMessage({ type: 'dice-roll', payload: { seed, count } });
+  };
+
+  const rollDice = () => {
+    const hasCrypto = typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function';
+    const seed = hasCrypto
+      ? crypto.getRandomValues(new Uint32Array(1))[0]
+      : Math.floor(Math.random() * 1_000_000_000) || Date.now();
+    setStatus('rolling');
+    broadcastRoll(seed, diceCount);
+    startSimulation(seed, diceCount);
+  };
+
+  return (
+    <div className="dice-overlay" aria-label="dice-overlay">
+      <canvas ref={canvasRef} className="dice-canvas" width={ARENA_WIDTH} height={ARENA_HEIGHT} aria-label="dice-canvas" />
+      <div className="dice-controls" aria-live="polite">
+        <div className="dice-count">Dice: {diceCount}</div>
+        <div className="dice-buttons">
+          <button type="button" onClick={() => setDiceCount((prev) => Math.max(1, prev - 1))} aria-label="decrease dice">
+            -
+          </button>
+          <button type="button" onClick={() => setDiceCount((prev) => Math.min(12, prev + 1))} aria-label="increase dice">
+            +
+          </button>
+        </div>
+        <button type="button" className="roll-button" onClick={rollDice} aria-label="roll dice">
+          Roll dice
+        </button>
+        <div className="dice-status" data-state={status}>
+          {status === 'rolling' ? 'Rolling...' : status === 'settled' ? 'Result locked' : 'Idle'}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DiceOverlay.propTypes = {
+  roomId: PropTypes.string,
+};
+
+export default DiceOverlay;

--- a/src/components/Room.jsx
+++ b/src/components/Room.jsx
@@ -139,6 +139,7 @@ const Room = ({ roomId, user, images, participants, onImagesUpdate, onLogout }) 
       <Canvas
         images={images}
         isGM={isGM}
+        roomId={roomId}
         onUploadFiles={handleUpload}
         onShareUrl={handleShareUrl}
         onMoveImage={handleMoveImage}

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -97,4 +97,20 @@ test.describe('drag-drop and zoom', () => {
     expect(afterTransform).not.toEqual(initialTransform);
     expect(afterTransform).toContain('translate(');
   });
+
+  test('dice overlay can be triggered', async ({ page }) => {
+    await page.goto('/');
+    await page.fill('input[placeholder="Room"]', 'gamma');
+    await page.fill('input[placeholder="Display name"]', 'Viewer');
+    await page.selectOption('select', 'player');
+    await page.click('button:has-text("Enter")');
+
+    const rollButton = page.getByRole('button', { name: /roll dice/i });
+    await expect(rollButton).toBeVisible();
+    await rollButton.click();
+
+    const status = page.locator('.dice-status');
+    await expect(status).toHaveAttribute('data-state', /rolling|settled/);
+    await expect(page.getByLabel('dice-canvas')).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- add a Three.js-based dice overlay with deterministic physics, shared seeds per room, and UI controls
- style the overlay for fixed-size bounds and ensure canvas panning ignores the dice controls
- add an end-to-end test that verifies the dice roll controls render and activate

## Testing
- npm run test:e2e


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd8c9d90c8322bfdff11ff5f90185)