### PR TITLE
Use Rapier for dice physics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vtrpg-client",
       "version": "0.1.0",
       "dependencies": {
+        "@dimforge/rapier3d-compat": "^0.19.3",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -284,6 +285,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.19.3.tgz",
+      "integrity": "sha512-mMVdSj1PRTT108s9Swbu2GQOmHbn8kbJANRV5xfczL3s0T4vkgZAuoMRgvBzQcHanpKusbC0ZJj6z3mC3aj3vg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dimforge/rapier3d-compat": "^0.19.3",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
- replace the dice overlay's custom physics with a Rapier-based simulation including arena boundaries
- synchronize Three.js meshes from Rapier rigid bodies with damping to settle rolls
- add the Rapier dependency and initialize physics on load while retaining broadcast-based rolls

## Testing
- npm run test:e2e *(fails: Playwright browsers missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6c371c808322977ec82239b0caee)