### PR TITLE
Add shareable room invites

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -320,6 +320,10 @@ func (s *Server) handleRoom(w http.ResponseWriter, r *http.Request) {
 	trimmed := strings.Trim(strings.TrimPrefix(r.URL.Path, "/rooms/"), "/")
 	parts := strings.Split(trimmed, "/")
 	if len(parts) < 2 || parts[0] == "" {
+		if r.Method == http.MethodGet || r.Method == http.MethodHead {
+			s.spaHandler().ServeHTTP(w, r)
+			return
+		}
 		http.NotFound(w, r)
 		return
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.11.0",
         "three": "^0.182.0"
       },
       "devDependencies": {
@@ -1616,6 +1617,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3618,6 +3632,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.11.0.tgz",
+      "integrity": "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.11.0.tgz",
+      "integrity": "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.11.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -3844,6 +3896,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.11.0",
     "three": "^0.182.0"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,34 @@
   gap: 0.5rem;
 }
 
+.page {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.page__form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.page__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.page__actions button {
+  width: auto;
+}
+
+.muted {
+  color: #94a3b8;
+  margin: 0;
+}
+
 .card input,
 .card select,
 .card button,

--- a/src/components/JoinBySlug.jsx
+++ b/src/components/JoinBySlug.jsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useNavigate, useParams } from 'react-router-dom';
+
+const JoinBySlug = ({ onJoinSuccess, existingSession }) => {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const [room, setRoom] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [name, setName] = useState('');
+  const [joining, setJoining] = useState(false);
+
+  const loadRoom = useCallback(() => {
+    if (!slug) return;
+    setRoom(null);
+    setLoading(true);
+    setError('');
+    fetch(`/rooms/slug/${slug}`)
+      .then(async (response) => {
+        if (response.ok) return response.json();
+        const payload = await response.json().catch(() => ({}));
+        if (response.status === 404) {
+          throw new Error('Rummet kunde inte hittas.');
+        }
+        throw new Error(payload?.error || 'Kunde inte hämta rummet.');
+      })
+      .then((data) => {
+        setRoom(data);
+      })
+      .catch((err) => {
+        setError(err.message || 'Kunde inte ladda rummet.');
+      })
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  useEffect(() => {
+    if (!slug) return;
+    if (existingSession?.roomSlug === slug || existingSession?.roomId === slug) {
+      navigate(`/rooms/${existingSession.roomSlug || existingSession.roomId}`, { replace: true });
+      return;
+    }
+
+    loadRoom();
+  }, [slug, existingSession, navigate, loadRoom]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!slug || !name.trim()) return;
+    setJoining(true);
+    setError('');
+    try {
+      const response = await fetch('/rooms/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slug, name: name.trim(), role: 'player' }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Kunde inte gå med i rummet.');
+      }
+      onJoinSuccess?.(payload, slug);
+      navigate(`/rooms/${payload.roomSlug || slug || payload.roomId}`, { replace: true });
+    } catch (err) {
+      setError(err.message || 'Kunde inte gå med i rummet.');
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const showForm = !loading && !error;
+  const roomName = room?.name || 'Namnlöst rum';
+
+  return (
+    <section className="page">
+      <div className="card">
+        <h2>Gå med i rum</h2>
+        {loading && <p>Laddar rum...</p>}
+        {error && (
+          <>
+            <p className="error">{error}</p>
+            <div className="page__actions">
+              <button type="button" onClick={loadRoom} disabled={loading}>
+                Försök igen
+              </button>
+              <button type="button" className="ghost-button" onClick={() => navigate('/')}>
+                Till startsidan
+              </button>
+            </div>
+          </>
+        )}
+        {showForm && (
+          <>
+            <p className="muted">
+              Du ansluter till <strong>{roomName}</strong> ({room?.slug || slug}).
+            </p>
+            <form onSubmit={handleSubmit} className="page__form">
+              <label>
+                Ditt namn
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                  minLength={2}
+                  maxLength={32}
+                  placeholder="Ange spelarnamn"
+                />
+              </label>
+              <p className="muted">Du ansluter som spelare.</p>
+              <div className="page__actions">
+                <button type="submit" disabled={joining}>
+                  {joining ? 'Ansluter...' : 'Gå med i rummet'}
+                </button>
+                <button type="button" className="ghost-button" onClick={() => navigate('/')}>
+                  Till startsidan
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </section>
+  );
+};
+
+JoinBySlug.propTypes = {
+  onJoinSuccess: PropTypes.func,
+  existingSession: PropTypes.shape({
+    roomId: PropTypes.string,
+    roomSlug: PropTypes.string,
+    user: PropTypes.shape({
+      name: PropTypes.string,
+      role: PropTypes.string,
+    }),
+  }),
+};
+
+export default JoinBySlug;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -42,8 +42,8 @@ const Login = ({ onLogin, defaultRoom, onRoomChange, buildInviteUrl }) => {
 
     if (!gmCheckPassed) return;
 
-    onLogin({ name, role });
-    onRoomChange(room);
+    onLogin({ name, role }, room);
+    onRoomChange?.(room);
   };
 
   const handleCreateRoom = async () => {
@@ -69,7 +69,7 @@ const Login = ({ onLogin, defaultRoom, onRoomChange, buildInviteUrl }) => {
         throw new Error('Kunde inte hämta rums-ID.');
       }
       setRoom(slug);
-      onRoomChange(slug);
+      onRoomChange?.(slug);
       if (buildInviteUrl) {
         setInviteLink(buildInviteUrl(slug));
       }
@@ -165,7 +165,7 @@ const Login = ({ onLogin, defaultRoom, onRoomChange, buildInviteUrl }) => {
 Login.propTypes = {
   onLogin: PropTypes.func.isRequired,
   defaultRoom: PropTypes.string,
-  onRoomChange: PropTypes.func.isRequired,
+  onRoomChange: PropTypes.func,
   buildInviteUrl: PropTypes.func,
 };
 

--- a/src/components/Room.jsx
+++ b/src/components/Room.jsx
@@ -250,6 +250,8 @@ Room.propTypes = {
   user: PropTypes.shape({
     name: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
+    id: PropTypes.string,
+    token: PropTypes.string,
   }).isRequired,
   participants: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- allow creating rooms from the login view and surface a copyable invite URL based on the generated slug
- expose the invite link inside active rooms with a copy helper and styling updates for the new UI
- avoid overwriting invited slugs when restoring sessions by reading the initial URL before syncing state

## Testing
- npm run test:e2e


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694806a2eaf483229629938a4ab425bc)