### PR TITLE
Fix D6 face-normal mapping and add dice-normal alignment debug tooling

### DIFF
--- a/docs/dice-normal-alignment.md
+++ b/docs/dice-normal-alignment.md
@@ -1,0 +1,81 @@
+# Aligning dice face normals with rendered models
+
+This project determines the upward-facing value by rotating predefined face normals by the die's final quaternion and choosing the normal that is most aligned with the world up vector `(0, 0, 1)`. When the face normals do not match how numbers are placed on the model, the calculated result will be wrong even though the physics is correct. The relevant mapping lives in `DICE_FACE_NORMALS` in `src/components/DiceRenderer.jsx`.
+
+To make the alignment process repeatable, a debug mode is available.
+
+## Debug mode helpers
+
+Enable dice debug mode by adding query parameters to a room URL:
+
+```text
+/rooms/<room-slug>?diceDebug=1&diceStepsPerFrame=8&diceClearMin=20000
+```
+
+Useful parameters:
+
+- `diceDebug=1`: Enables debug output and helpers described below.
+- `diceStepsPerFrame=<n>`: Advances multiple physics steps per animation frame in debug mode (default `6`). This dramatically speeds up iteration without affecting normal gameplay.
+- `diceClearMin=<ms>`: Ensures dice stay on screen for at least this duration in debug mode.
+- `diceVelocity=<multiplier>`: Scales linear velocity in debug mode if you need calmer or more chaotic rolls.
+- `diceSeed=<uint32>`: Optional fixed seed applied on page load.
+
+When debug mode is enabled:
+
+- The last roll's analysis is exposed at `window.__diceDebugLastResults`.
+- You can force a specific seed without reloading the page by setting `window.__diceDebugSeedOverride` in the browser console before rolling.
+
+Each entry in `window.__diceDebugLastResults` includes:
+
+- `topValue`: the calculated result.
+- `bestNormal`: the local-space normal that was treated as "up".
+- `screen`: the die center in canvas pixel coordinates (useful for targeted screenshots).
+
+## Step-by-step alignment workflow
+
+1. **Open a room as GM** and append debug params, for example:
+   `/rooms/<room-slug>?diceDebug=1&diceStepsPerFrame=8&diceClearMin=20000`.
+2. **Reduce to one die** and select the die type you want to align (e.g., `d6`).
+3. **Set a seed** in the browser console:
+   `window.__diceDebugSeedOverride = 12`.
+4. Click **Roll dice**.
+5. Compare:
+   - The number rendered on the top face.
+   - The calculated result in `window.__diceDebugLastResults[0].topValue` (or the Dice Log).
+6. Record the mapping between:
+   - `bestNormal` (the direction in local space).
+   - The number you actually see on top.
+7. Update `DICE_FACE_NORMALS` so each normal points to the number that is actually printed on that face.
+8. Repeat with additional seeds until all faces have been confirmed.
+
+### Tip: cover all directions quickly
+
+In debug mode, you can scan seeds quickly by repeatedly setting `window.__diceDebugSeedOverride` and rolling. Once you observe a new `bestNormal` direction (`±X`, `±Y`, `±Z`), capture the mapping and move on.
+
+## D6 alignment result
+
+Using the workflow above, the d6 model maps to normals as follows:
+
+- `+Z` → `3`
+- `-Z` → `4`
+- `+Y` → `1`
+- `-Y` → `6`
+- `+X` → `5`
+- `-X` → `2`
+
+This mapping preserves standard opposite sides summing to 7.
+
+## Applying this to other dice
+
+For other dice types (d8, d10, d12, d20):
+
+1. Enable debug mode with the same query parameters.
+2. Select the die type you want to align.
+3. Use `window.__diceDebugSeedOverride = <seed>` to iterate through different outcomes.
+4. For each roll, read:
+   - The rendered top value.
+   - The `bestNormal` direction from `window.__diceDebugLastResults`.
+5. Update the corresponding entry in `DICE_FACE_NORMALS`.
+6. Verify with several seeds after the update.
+
+Because debug mode is gated behind `diceDebug=1`, these helpers do not change normal gameplay.

--- a/src/components/DiceRenderer.jsx
+++ b/src/components/DiceRenderer.jsx
@@ -19,12 +19,12 @@ export const DICE_FACE_NORMALS = {
     { value: 4, normal: new THREE.Vector3(-0.577, 0.577, -0.577) },
   ],
   6: [
-    { value: 1, normal: new THREE.Vector3(0, 0, 1) },
-    { value: 6, normal: new THREE.Vector3(0, 0, -1) },
-    { value: 2, normal: new THREE.Vector3(0, 1, 0) },
-    { value: 5, normal: new THREE.Vector3(0, -1, 0) },
-    { value: 3, normal: new THREE.Vector3(1, 0, 0) },
-    { value: 4, normal: new THREE.Vector3(-1, 0, 0) },
+    { value: 3, normal: new THREE.Vector3(0, 0, 1) },
+    { value: 4, normal: new THREE.Vector3(0, 0, -1) },
+    { value: 1, normal: new THREE.Vector3(0, 1, 0) },
+    { value: 6, normal: new THREE.Vector3(0, -1, 0) },
+    { value: 5, normal: new THREE.Vector3(1, 0, 0) },
+    { value: 2, normal: new THREE.Vector3(-1, 0, 0) },
   ],
   8: [
     { value: 1, normal: new THREE.Vector3(0.577, 0.577, 0.577) },
@@ -150,8 +150,8 @@ export const extractVertices = (geometry) => {
   return unique;
 };
 
-export const createColliderForSides = (RAPIER, sides, vertices) => {
-  const dieSize = DIE_SCALES[sides];
+export const createColliderForSides = (RAPIER, sides, vertices, scaleMultiplier = 1) => {
+  const dieSize = DIE_SCALES[sides] * scaleMultiplier;
   
   if (sides === 6) {
     return RAPIER.ColliderDesc.cuboid(dieSize / 2, dieSize / 2, dieSize / 2)
@@ -159,7 +159,17 @@ export const createColliderForSides = (RAPIER, sides, vertices) => {
       .setFriction(0.32);
   }
 
-  const convex = RAPIER.ColliderDesc.convexHull(new Float32Array(vertices));
+  let scaledVertices;
+  if (scaleMultiplier === 1) {
+    scaledVertices = new Float32Array(vertices);
+  } else {
+    scaledVertices = new Float32Array(vertices.length);
+    for (let i = 0; i < vertices.length; i += 1) {
+      scaledVertices[i] = vertices[i] * scaleMultiplier;
+    }
+  }
+
+  const convex = RAPIER.ColliderDesc.convexHull(scaledVertices);
   if (convex) {
     convex.setRestitution(0.55).setFriction(0.32);
     return convex;


### PR DESCRIPTION
### Motivation
- Rendered D6 top face didn't match the value calculated from the die's face normals because the `DICE_FACE_NORMALS` mapping for d6 was incorrect.\
- Iterative manual alignment of normals is slow and error-prone, so a debug workflow and tooling were added to make repeating the process deterministic and fast.\

### Description
- Corrected the d6 mapping in `DICE_FACE_NORMALS` so axes now map to the numbers printed on the model (`+Z→3`, `-Z→4`, `+Y→1`, `-Y→6`, `+X→5`, `-X→2`).\
- Added URL-driven debug mode to `DiceOverlay.jsx` with parameters `diceDebug`, `diceSeed`, `diceVelocity`, `diceClearMin`, and `diceStepsPerFrame`, and exposed the last roll analysis on `window.__diceDebugLastResults`.\
- Implemented deterministic seed override via `window.__diceDebugSeedOverride` and exposed the used seed as `window.__diceDebugLastSeed` for repeatable rolls.\
- Added debug-only accelerated physics stepping and a screen-projection helper for targeted screenshots to speed iterations without changing normal gameplay.\
- Made `createColliderForSides` accept an optional `scaleMultiplier` and properly scale vertex arrays when building convex hull colliders.\
- Documented the full reproducible alignment workflow and the resolved d6 mapping in `docs/dice-normal-alignment.md` (new file).\

### Testing
- Ran backend unit tests with `go test ./...` and they passed (`ok vtrpg/internal/server`).\
- Ran frontend lint with `npm run lint` and it completed successfully.\
- Installed Playwright browsers (`npx playwright install --with-deps`) and ran end-to-end test suite with `npm run test:e2e`; all Playwright e2e tests passed (27 passed).\
- Performed deterministic visual validation using automated Playwright scripts that exercised the debug mode and verified top-face -> calculated result consistency for representative seeds; screenshots and debug output were produced during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750aca70a0832285b4c342ee447fc5)